### PR TITLE
Improved consistency of checks for flush

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -405,13 +405,15 @@ def _save(im, fp, filename, eps=1):
     fp.write("[%d 0 0 -%d 0 %d]\n" % (im.size[0], im.size[1], im.size[1]))
     fp.write("{ currentfile buf readhexstring pop } bind\n")
     fp.write(operator[2] + "\n")
-    fp.flush()
+    if hasattr(fp, "flush"):
+        fp.flush()
 
     ImageFile._save(im, base_fp, [("eps", (0, 0)+im.size, 0, None)])
 
     fp.write("\n%%%%EndBinary\n")
     fp.write("grestore end\n")
-    fp.flush()
+    if hasattr(fp, "flush"):
+        fp.flush()
 
 #
 # --------------------------------------------------------------------

--- a/PIL/IcnsImagePlugin.py
+++ b/PIL/IcnsImagePlugin.py
@@ -306,10 +306,8 @@ def _save(im, fp, filename):
 
     OS X only.
     """
-    try:
+    if hasattr(fp, "flush"):
         fp.flush()
-    except:
-        pass
 
     # create the temporary set of pngs
     iconset = tempfile.mkdtemp('.iconset')

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -493,10 +493,8 @@ def _save(im, fp, tile, bufsize=0):
             if s < 0:
                 raise IOError("encoder error %d when writing image file" % s)
             e.cleanup()
-    try:
+    if hasattr(fp, "flush"):
         fp.flush()
-    except:
-        pass
 
 
 def _safe_read(fp, size):

--- a/PIL/PalmImagePlugin.py
+++ b/PIL/PalmImagePlugin.py
@@ -227,7 +227,8 @@ def _save(im, fp, filename, check=0):
     ImageFile._save(
         im, fp, [("raw", (0, 0)+im.size, 0, (rawmode, rowbytes, 1))])
 
-    fp.flush()
+    if hasattr(fp, "flush"):
+        fp.flush()
 
 
 #

--- a/PIL/PdfImagePlugin.py
+++ b/PIL/PdfImagePlugin.py
@@ -226,7 +226,8 @@ def _save(im, fp, filename):
         fp.write("%010d 00000 n \n" % x)
     fp.write("trailer\n<<\n/Size %d\n/Root 1 0 R\n>>\n" % len(xref))
     fp.write("startxref\n%d\n%%%%EOF\n" % startxref)
-    fp.flush()
+    if hasattr(fp, "flush"):
+        fp.flush()
 
 #
 # --------------------------------------------------------------------

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -762,10 +762,8 @@ def _save(im, fp, filename, chunk=putchunk, check=0):
 
     chunk(fp, b"IEND", b"")
 
-    try:
+    if hasattr(fp, "flush"):
         fp.flush()
-    except:
-        pass
 
 
 # --------------------------------------------------------------------

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -935,8 +935,7 @@ class TiffImageFile(ImageFile.ImageFile):
                     # flush the file descriptor, prevents error on pypy 2.4+
                     # should also eliminate the need for fp.tell for py3
                     # in _seek
-                    # flush method may not exist for file-like object.
-                    if hasattr(self.fp, 'flush'):
+                    if hasattr(self.fp, "flush"):
                         self.fp.flush()
                 except IOError:
                     # io.BytesIO have a fileno, but returns an IOError if


### PR DESCRIPTION
Rather than creating a separate PR to replace yours, I thought I'd try and contribute to yours instead.

This takes your check for `flush` and applies it to other situations in Pillow, and also changes some EAFP checks to `hasattr` to be consistent and specific.